### PR TITLE
fix: replace 'Welcome Back' with neutral copy on login page

### DIFF
--- a/frontend/src/components/auth/auth-form.tsx
+++ b/frontend/src/components/auth/auth-form.tsx
@@ -147,7 +147,7 @@ export function AuthForm({ initialMode = 'login', resetToken }: AuthFormProps) {
 
   const getTitle = () => {
     switch (mode) {
-      case 'login': return 'Welcome Back'
+      case 'login': return 'Sign In'
       case 'register': return 'Create Account'
       case 'forgot-password': return 'Forgot Password'
       case 'reset-password': return 'Reset Password'
@@ -156,7 +156,7 @@ export function AuthForm({ initialMode = 'login', resetToken }: AuthFormProps) {
 
   const getDescription = () => {
     switch (mode) {
-      case 'login': return 'Sign in to your CuraGenie account'
+      case 'login': return 'Sign in or create a new CuraGenie account'
       case 'register': return 'Join CuraGenie for personalized healthcare insights'
       case 'forgot-password': return 'Enter your email to receive reset instructions'
       case 'reset-password': return 'Enter your new password'


### PR DESCRIPTION
## Description

Replaced the "Welcome Back" heading and generic subtitle on the login page with neutral copy that doesn't assume prior user familiarity. New users visiting /login for the first time were greeted as returning users, which was misleading UX.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Fixes #14 

## Changes Made

- Changed login title from 'Welcome Back' to 'Sign In' in auth-form.tsx
- Changed login subtitle from 'Sign in to your CuraGenie account' to 'Sign in or create a new CuraGenie account' in auth-form.tsx

## Testing

- [x] Tested locally
- [x] Manual testing performed

### Test Details

Navigated to /auth/login as a first-time user. Confirmed the heading now shows "Sign In" and the subtitle is neutral. Verified the register flow still shows "Create Account" and "Join CuraGenie for personalized healthcare insights" unchanged. No regressions observed.

## Screenshots

Before Fix, on first time app launch:
<img width="1916" height="1009" alt="Screenshot 2026-06-06 190046" src="https://github.com/user-attachments/assets/63eaccc5-ccfc-4530-887b-eeb3cfe2e0bc" />

After Fix:
<img width="1912" height="1017" alt="image" src="https://github.com/user-attachments/assets/90b7d325-3cbc-437d-adf0-278e259eabe6" />

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Additional Notes

Only two lines changed in one file (auth-form.tsx). No logic, no dependencies, no breaking changes. The register flow copy was already correct and is untouched.
